### PR TITLE
Normalize workspace-relative paths with parent segments

### DIFF
--- a/bin/workspaceRoots.js
+++ b/bin/workspaceRoots.js
@@ -18,6 +18,27 @@ function normalizeLogicalPath(requestedPath) {
     .replace(/^\/+/, '');
 }
 
+function normalizeResolvedLogicalPath(logicalPath) {
+  const segments = normalizeLogicalPath(logicalPath).split('/').filter(Boolean);
+  const stack = [];
+
+  for (const segment of segments) {
+    if (segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      if (stack.length === 0) {
+        return null;
+      }
+      stack.pop();
+      continue;
+    }
+    stack.push(segment);
+  }
+
+  return stack.join('/') || '.';
+}
+
 function hasParentTraversal(logicalPath) {
   return logicalPath.split('/').some((segment) => segment === '..');
 }
@@ -68,9 +89,13 @@ function resolveLogicalPathForRoot(apiRoot, requestedPath, appRoot, workspaceRoo
     return null;
   }
 
-  const logicalPath = normalizeLogicalPath(
+  const rawLogicalPath = normalizeLogicalPath(
     settings.fromUrlPath ? String(requestedPath || '').replace(/^\/+/, '') : requestedPath
   );
+  const logicalPath = normalizeResolvedLogicalPath(rawLogicalPath);
+  if (logicalPath === null) {
+    return null;
+  }
 
   if (parsedRoot === 'workspace' && isForbiddenWorkspacePath(logicalPath)) {
     return null;

--- a/bin/workspaceRoots.test.js
+++ b/bin/workspaceRoots.test.js
@@ -52,6 +52,16 @@ test('resolveLogicalPathForRoot maps sample API paths to app samples directory',
   );
 });
 
+test('resolveLogicalPathForRoot resolves parent segments in workspace paths', () => {
+  const resolved = resolveLogicalPathForRoot(
+    'workspace',
+    'sims/babyboot/chaotic/../babyboot.txt',
+    appRoot,
+    workspaceRoot
+  );
+  assert.equal(resolved, path.join(workspaceRoot, 'sims/babyboot/babyboot.txt'));
+});
+
 test('resolveLogicalPathForRoot maps workspace API paths to workspace root', () => {
   const simPath = resolveLogicalPathForRoot('workspace', 'my_sim_folder/run.1', appRoot, workspaceRoot);
   assert.equal(simPath, path.resolve(workspaceRoot, 'my_sim_folder/run.1'));

--- a/frontend/src/core/pathUtils.ts
+++ b/frontend/src/core/pathUtils.ts
@@ -2,6 +2,30 @@ export function normalizePathSeparators(path: string): string {
   return path.replace(/\\/g, '/');
 }
 
+export function normalizeWorkspaceRelativePath(path: string): string | null {
+  const segments = normalizePathSeparators(path)
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter((segment) => segment.length > 0);
+  const stack: string[] = [];
+
+  for (const segment of segments) {
+    if (segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      if (stack.length === 0) {
+        return null;
+      }
+      stack.pop();
+      continue;
+    }
+    stack.push(segment);
+  }
+
+  return stack.join('/') || '.';
+}
+
 export function getBasePath(path: string): string {
   const normalized = normalizePathSeparators(path);
   const slashIndex = normalized.lastIndexOf('/');

--- a/frontend/src/core/sceneDocument.test.ts
+++ b/frontend/src/core/sceneDocument.test.ts
@@ -5,7 +5,7 @@ import { readFile } from 'node:fs/promises';
 import { createSceneDocument, DEFAULT_POINT_MARKER_WORKSPACE_FRACTION } from './sceneDocument.ts';
 import { buildObjectInspections, collectSceneDiagnostics } from './sceneInspector.ts';
 import { expandSimulationFiles } from './expandSimulationFiles.ts';
-import { getBasePath, getFileExtension, getRelativePath } from './pathUtils.ts';
+import { getBasePath, getFileExtension, getRelativePath, normalizeWorkspaceRelativePath } from './pathUtils.ts';
 import type { SceneConfig } from './types.ts';
 
 async function readSceneFixture(relativePath: string): Promise<SceneConfig> {
@@ -22,6 +22,11 @@ test('path helpers preserve MGView-style relative paths', () => {
     getRelativePath('samples/tricycle/', 'samples/common/demo.1'),
     '../common/demo.1'
   );
+  assert.equal(
+    normalizeWorkspaceRelativePath('sims/babyboot/chaotic/../babyboot.txt'),
+    'sims/babyboot/babyboot.txt'
+  );
+  assert.equal(normalizeWorkspaceRelativePath('../escape.txt'), null);
 });
 
 test('simulation file expansion matches legacy numeric range behavior', () => {


### PR DESCRIPTION
## Summary
- Resolve `..` and `.` segments in workspace API paths on the server (`workspaceRoots.js`) and in frontend path helpers (`normalizeWorkspaceRelativePath`).
- Add tests covering canonicalization of paths like `sims/babyboot/chaotic/../babyboot.txt` and rejection of paths that escape the workspace root.

## Test plan
- [ ] `node --test bin/workspaceRoots.test.js`
- [ ] `node --experimental-strip-types --test frontend/src/core/sceneDocument.test.ts`
- [ ] Load a workspace scene whose `simulationData` or related paths use parent segments and confirm files resolve correctly


Made with [Cursor](https://cursor.com)