### PR TITLE
Stop overlay dismiss events from bubbling

### DIFF
--- a/frontend/src/components/OverlayPanel.tsx
+++ b/frontend/src/components/OverlayPanel.tsx
@@ -28,7 +28,19 @@ export default function OverlayPanel({
 }: OverlayPanelProps) {
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent size={size} onPointerDownOutside={onClose} onEscapeKeyDown={onClose}>
+      <DialogContent
+        size={size}
+        onPointerDownOutside={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onClose();
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onClose();
+        }}
+      >
         <DialogHeader>
           <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
             <div>


### PR DESCRIPTION
## Summary
- Prevent `onPointerDownOutside` and `onEscapeKeyDown` handlers on dialog overlays from propagating events after closing.
- Fixes cases where dismissing an overlay could interfere with other UI interactions underneath.

Stacked on #12.

## Test plan
- [ ] Open a workspace picker or other overlay, dismiss via click-outside and Escape, confirm no stray clicks land on the workspace beneath
- [ ] Confirm overlay still closes normally for both dismiss methods


Made with [Cursor](https://cursor.com)